### PR TITLE
Added cross-env package to support DevProxy on multiple OS

### DIFF
--- a/templates/nodejs-graphconnectors/templates/ts/package.json
+++ b/templates/nodejs-graphconnectors/templates/ts/package.json
@@ -8,9 +8,9 @@
     "build": "tsc",
     "clean": "rimraf dist",
     "start:createConnection": "node dist/createConnection.js",
-    "start:createConnection:proxy": "http_proxy=http://127.0.0.1:8000 NODE_TLS_REJECT_UNAUTHORIZED=0 NODE_NO_WARNINGS=1 node dist/createConnection.js",
+    "start:createConnection:proxy": "cross-env http_proxy=http://127.0.0.1:8000 NODE_TLS_REJECT_UNAUTHORIZED=0 NODE_NO_WARNINGS=1 node dist/createConnection.js",
     "start:loadContent": "node dist/loadContent.js",
-    "start:loadContent:proxy": "http_proxy=http://127.0.0.1:8000 NODE_TLS_REJECT_UNAUTHORIZED=0 NODE_NO_WARNINGS=1 node dist/loadContent.js",
+    "start:loadContent:proxy": "cross-env http_proxy=http://127.0.0.1:8000 NODE_TLS_REJECT_UNAUTHORIZED=0 NODE_NO_WARNINGS=1 node dist/loadContent.js",
     "watch": "tsc -w"
   },
   "keywords": [],
@@ -20,7 +20,8 @@
     "@microsoft/microsoft-graph-types": "^2.40.0",
     "@types/node": "^20.14.10",
     "rimraf": "^6.0.1",
-    "typescript": "^5.5.3"
+    "typescript": "^5.5.3",
+    "cross-env": "^7.0.3"
   },
   "dependencies": {
     "@azure/identity": "^4.3.0",


### PR DESCRIPTION
``The template generated with Node.js and TypeScript supports a variant of the commands with the :proxy suffix, which allows to simulate the API execution by intercepting the requests to the Microsoft Graph and generating mock responses using DevProxy.
The command executes the following script, which sets a series of environment variables that are read by the application to set up DevProxy as application proxy:

```bash
http_proxy=http://127.0.0.1:8000 NODE_TLS_REJECT_UNAUTHORIZED=0 NODE_NO_WARNINGS=1 node dist/createConnection.js
```

The problem is that this approach works only on Unix (so Linux and MacOS). If you try to run the script on Windows, you'll get an error.

This PR addresses the problem, by adding a package from NPM called [cross-env](https://www.npmjs.com/package/cross-env) and by replacing the script with the following command:

```bash
cross-env http_proxy=http://127.0.0.1:8000 NODE_TLS_REJECT_UNAUTHORIZED=0 NODE_NO_WARNINGS=1 node dist/createConnection.js
```

Thanks to this command, the script will be executed correctly on every operating system.

I tested this on Windows 11 24H2 and on Ubuntu (using WSL2 on Windows). 